### PR TITLE
Allow the nodes container attribute to use a different name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ var treeObject = {
 	]
 };
 var tree = new Backbone.TreeModel(treeObject);
+
+Backbone.TreeModel can be extended with a `nodesAttribute` property. Defaults to `nodes`, but can be changed if the nodes exist in a container with a different name.
 ```
 
 ###2. Traversing Tree

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ var treeObject = {
 };
 var tree = new Backbone.TreeModel(treeObject);
 
-Backbone.TreeModel can be extended with a `nodesAttribute` property. Defaults to `nodes`, but can be changed if the nodes exist in a container with a different name.
 ```
+
+Backbone.TreeModel can be extended with a `nodesAttribute` property. Defaults to `nodes`, but can be changed if the nodes exist in a container with a different name.
 
 ###2. Traversing Tree
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "backbone-tree-model",
+  "version": "1.0.0",
+  "description": "A tree using Backbone Model and Collection",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shaine/backbone-tree-model"
+  },
+  "keywords": [
+    "backbone",
+    "tree"
+  ],
+  "author": "EnotionZ",
+  "bugs": {
+    "url": "https://github.com/shaine/backbone-tree-model/issues"
+  },
+  "homepage": "https://github.com/shaine/backbone-tree-model"
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "backbone-tree-model",
   "version": "1.0.0",
   "description": "A tree using Backbone Model and Collection",
+  "main": "src/backbone.treemodel.js",
   "directories": {
     "test": "test"
   },

--- a/test/backbone.tree_test.js
+++ b/test/backbone.tree_test.js
@@ -1,23 +1,25 @@
 var tree;
 describe('Backbone Tree', function() {
 	beforeEach(function() {
-		tree = new Backbone.TreeModel({
+		tree = new (Backbone.TreeModel.extend({
+			nodesAttribute: 'children'
+		}))({
 			id: 'root',
 			tagname: 'body',
-			nodes: [
+			children: [
 				{
 					id: 'wrapper',
 					tagname: 'div',
-					nodes: [
+					children: [
 						{
 							id: 'sidebar',
 							tagname: 'div',
 							width: 300,
-							nodes: [
+							children: [
 								{ tagname: 'p' },
 								{
 									tagname: 'ul',
-									nodes: [
+									children: [
 										{ tagname: 'li' },
 										{ tagname: 'li' },
 										{ tagname: 'li' }
@@ -30,17 +32,17 @@ describe('Backbone Tree', function() {
 							id: 'content',
 							tagname: 'div',
 							width: 600,
-							nodes: [
+							children: [
 								{
 									id: 'title',
 									tagname: 'h2'
 								},
 								{
 									tagname: 'p',
-									nodes: [
+									children: [
 										{
 											tagname: 'anchor',
-											nodes: [
+											children: [
 												{ tagname: 'span' }
 											]
 										}
@@ -141,11 +143,11 @@ describe('Backbone Tree', function() {
 				{
 					id: 'title_2',
 					tagname: 'h1',
-					nodes: [
+					children: [
 						{
 							id: 'anchor',
 							tagname: 'a',
-							nodes: [
+							children: [
 								{ tagname: 'span' }
 							]
 						}
@@ -261,12 +263,12 @@ describe('Backbone Tree', function() {
 			tree.find('sidebar').remove(); // perform a change
 
 			var treeJSON = tree.toJSON();
-			expect(treeJSON.nodes[0].nodes.length).to.be(1);
-			expect(treeJSON.nodes[0].nodes[0].id).to.be('content');
+			expect(treeJSON.children[0].children.length).to.be(1);
+			expect(treeJSON.children[0].children[0].id).to.be('content');
 
 			var wrapperJSON = tree.find('wrapper').toJSON();
-			expect(wrapperJSON.nodes.length).to.be(1);
-			expect(wrapperJSON.nodes[0].id).to.be('content');
+			expect(wrapperJSON.children.length).to.be(1);
+			expect(wrapperJSON.children[0].id).to.be('content');
 		});
 	});
 


### PR DESCRIPTION
Allow TreeModel to be extended with a `nodesAttribute` property, defaults to `nodes`. Updated tests and documentation to reflect the change.
